### PR TITLE
187/Naming generics

### DIFF
--- a/core/src/main/java/com/novoda/pxfetcher/DefaultTagWrapper.java
+++ b/core/src/main/java/com/novoda/pxfetcher/DefaultTagWrapper.java
@@ -2,15 +2,22 @@ package com.novoda.pxfetcher;
 
 import com.novoda.pxfetcher.task.TagWrapper;
 
-public class DefaultTagWrapper extends TagWrapper<Void> {
+public class DefaultTagWrapper<MetadataType> extends TagWrapper<MetadataType> {
+
+    private final MetadataType metadata;
 
     public DefaultTagWrapper(String url) {
+        this(url, null);
+    }
+
+    public DefaultTagWrapper(String url, MetadataType metadata) {
         super(url);
+        this.metadata = metadata;
     }
 
     @Override
-    public Void getMetadata() {
-        return null;
+    public MetadataType getMetadata() {
+        return metadata;
     }
 
 }

--- a/core/src/main/java/com/novoda/pxfetcher/FallbackStrategyRetriever.java
+++ b/core/src/main/java/com/novoda/pxfetcher/FallbackStrategyRetriever.java
@@ -5,17 +5,17 @@ import com.novoda.pxfetcher.task.Retriever;
 import com.novoda.pxfetcher.task.Success;
 import com.novoda.pxfetcher.task.TagWrapper;
 
-public class FallbackStrategyRetriever<T extends TagWrapper<V>, V> implements Retriever<T, V> {
+public class FallbackStrategyRetriever<TagWrapperType extends TagWrapper<MetadataType>, MetadataType> implements Retriever<TagWrapperType, MetadataType> {
 
-    private final Retriever<T, V>[] retrievers;
+    private final Retriever<TagWrapperType, MetadataType>[] retrievers;
 
-    public FallbackStrategyRetriever(Retriever<T, V>... retrievers) {
+    public FallbackStrategyRetriever(Retriever<TagWrapperType, MetadataType>... retrievers) {
         this.retrievers = retrievers;
     }
 
     @Override
-    public Result retrieve(T tagWrapper) {
-        for (Retriever<T, V> retriever : retrievers) {
+    public Result retrieve(TagWrapperType tagWrapper) {
+        for (Retriever<TagWrapperType, MetadataType> retriever : retrievers) {
             Result result = retriever.retrieve(tagWrapper);
             if (result instanceof Success) {
                 return result;

--- a/core/src/main/java/com/novoda/pxfetcher/FileRetriever.java
+++ b/core/src/main/java/com/novoda/pxfetcher/FileRetriever.java
@@ -8,20 +8,20 @@ import com.novoda.pxfetcher.task.TagWrapper;
 
 import java.io.File;
 
-public class FileRetriever<T extends TagWrapper<V>, V> implements Retriever<T, V> {
+public class FileRetriever<TagWrapperType extends TagWrapper<MetadataType>, MetadataType> implements Retriever<TagWrapperType, MetadataType> {
 
-    private final FileNameFactory<V> fileNameFactory;
+    private final FileNameFactory<MetadataType> fileNameFactory;
     private final BitmapProcessor bitmapProcessor;
     private final BitmapDecoder decoder;
 
-    public FileRetriever(FileNameFactory<V> fileNameFactory, BitmapDecoder decoder, BitmapProcessor bitmapProcessor) {
+    public FileRetriever(FileNameFactory<MetadataType> fileNameFactory, BitmapDecoder decoder, BitmapProcessor bitmapProcessor) {
         this.fileNameFactory = fileNameFactory;
         this.bitmapProcessor = bitmapProcessor;
         this.decoder = decoder;
     }
 
     @Override
-    public Result retrieve(T tagWrapper) {
+    public Result retrieve(TagWrapperType tagWrapper) {
         Bitmap bitmap = innerRetrieve(tagWrapper);
         Bitmap elaborated = bitmapProcessor.elaborate(tagWrapper, bitmap);
         if (elaborated == null) {
@@ -30,7 +30,7 @@ public class FileRetriever<T extends TagWrapper<V>, V> implements Retriever<T, V
         return new Success(elaborated);
     }
 
-    private Bitmap innerRetrieve(T tagWrapper) {
+    private Bitmap innerRetrieve(TagWrapperType tagWrapper) {
         String sourceUrl = tagWrapper.getSourceUrl();
         String fileName = fileNameFactory.getFileName(sourceUrl, tagWrapper.getMetadata());
         File file = new File(fileName);

--- a/core/src/main/java/com/novoda/pxfetcher/MemoryRetriever.java
+++ b/core/src/main/java/com/novoda/pxfetcher/MemoryRetriever.java
@@ -2,12 +2,11 @@ package com.novoda.pxfetcher;
 
 import android.graphics.Bitmap;
 
-import com.novoda.pxfetcher.CacheManager;
 import com.novoda.pxfetcher.task.Result;
 import com.novoda.pxfetcher.task.Retriever;
 import com.novoda.pxfetcher.task.TagWrapper;
 
-public class MemoryRetriever<T extends TagWrapper<V>, V> implements Retriever<T,V> {
+public class MemoryRetriever<TagWrapperType extends TagWrapper<MetadataType>, MetadataType> implements Retriever<TagWrapperType, MetadataType> {
 
     private static final int IGNORED = 0;
     private final CacheManager cacheManager;
@@ -19,7 +18,7 @@ public class MemoryRetriever<T extends TagWrapper<V>, V> implements Retriever<T,
     }
 
     @Override
-    public Result retrieve(T tagWrapper) {
+    public Result retrieve(TagWrapperType tagWrapper) {
         Bitmap bitmap = innerRetrieve(tagWrapper);
         Bitmap elaborated = bitmapProcessor.elaborate(tagWrapper, bitmap);
         if (elaborated == null) {
@@ -28,7 +27,7 @@ public class MemoryRetriever<T extends TagWrapper<V>, V> implements Retriever<T,
         return new Success(elaborated);
     }
 
-    private Bitmap innerRetrieve(T tagWrapper) {
+    private Bitmap innerRetrieve(TagWrapperType tagWrapper) {
         return cacheManager.get(tagWrapper.getSourceUrl(), IGNORED, IGNORED);
     }
 

--- a/core/src/main/java/com/novoda/pxfetcher/NetworkRetriever.java
+++ b/core/src/main/java/com/novoda/pxfetcher/NetworkRetriever.java
@@ -8,14 +8,14 @@ import com.novoda.pxfetcher.task.TagWrapper;
 
 import java.io.File;
 
-public class NetworkRetriever<T extends TagWrapper<V>, V> implements Retriever<T, V> {
+public class NetworkRetriever<TagWrapperType extends TagWrapper<MetadataType>, MetadataType> implements Retriever<TagWrapperType, MetadataType> {
 
     private final ResourceManager resourceManager;
-    private final FileNameFactory<V> fileNameFactory;
+    private final FileNameFactory<MetadataType> fileNameFactory;
     private final BitmapProcessor bitmapProcessor;
     private final BitmapDecoder decoder;
 
-    public NetworkRetriever(ResourceManager resourceManager, FileNameFactory<V> fileNameFactory, BitmapDecoder decoder, BitmapProcessor bitmapProcessor) {
+    public NetworkRetriever(ResourceManager resourceManager, FileNameFactory<MetadataType> fileNameFactory, BitmapDecoder decoder, BitmapProcessor bitmapProcessor) {
         this.resourceManager = resourceManager;
         this.fileNameFactory = fileNameFactory;
         this.bitmapProcessor = bitmapProcessor;
@@ -23,7 +23,7 @@ public class NetworkRetriever<T extends TagWrapper<V>, V> implements Retriever<T
     }
 
     @Override
-    public Result retrieve(T tagWrapper) {
+    public Result retrieve(TagWrapperType tagWrapper) {
         Bitmap bitmap = innerRetrieve(tagWrapper);
         Bitmap elaborated = bitmapProcessor.elaborate(tagWrapper, bitmap);
         if (elaborated == null) {
@@ -32,7 +32,7 @@ public class NetworkRetriever<T extends TagWrapper<V>, V> implements Retriever<T
         return new Success(elaborated);
     }
 
-    private Bitmap innerRetrieve(T tagWrapper) {
+    private Bitmap innerRetrieve(TagWrapperType tagWrapper) {
         String sourceUrl = tagWrapper.getSourceUrl();
         String savedUrl = fileNameFactory.getFileName(sourceUrl, tagWrapper.getMetadata());
         File file = new File(savedUrl);

--- a/core/src/main/java/com/novoda/pxfetcher/RetrieverFactory.java
+++ b/core/src/main/java/com/novoda/pxfetcher/RetrieverFactory.java
@@ -5,16 +5,16 @@ import android.content.res.Resources;
 import com.novoda.pxfetcher.task.Retriever;
 import com.novoda.pxfetcher.task.TagWrapper;
 
-public class RetrieverFactory<T extends TagWrapper<V>, V> {
+public class RetrieverFactory<TagWrapperType extends TagWrapper<MetaDataType>, MetaDataType> {
 
     private static final double DEFAULT_ALLOWED_STRETCHING_THRESHOLD = .10;
     private final CacheManager cacheManager;
-    private final FileNameFactory<V> fileManager;
+    private final FileNameFactory<MetaDataType> fileManager;
     private final ResourceManager resourceManager;
     private final int maxDownsampling;
     private final Resources resources;
 
-    public RetrieverFactory(CacheManager cacheManager, FileNameFactory<V> fileNameFactory, ResourceManager resourceManager, int maxDownsampling, Resources resources) {
+    public RetrieverFactory(CacheManager cacheManager, FileNameFactory<MetaDataType> fileNameFactory, ResourceManager resourceManager, int maxDownsampling, Resources resources) {
         this.cacheManager = cacheManager;
         this.fileManager = fileNameFactory;
         this.resourceManager = resourceManager;
@@ -22,28 +22,28 @@ public class RetrieverFactory<T extends TagWrapper<V>, V> {
         this.resources = resources;
     }
 
-    public Retriever<T, V> createDefaultRetriever() {
+    public Retriever<TagWrapperType, MetaDataType> createDefaultRetriever() {
         Retriever memoryRetriever = createMemoryRetriever();
         Retriever fileRetriever = createFileRetriever();
         Retriever networkRetriever = createNetworkRetriever();
-        return new FallbackStrategyRetriever<T, V>(memoryRetriever, fileRetriever, networkRetriever);
+        return new FallbackStrategyRetriever<TagWrapperType, MetaDataType>(memoryRetriever, fileRetriever, networkRetriever);
     }
 
-    public Retriever<T, V> createMemoryRetriever() {
+    public Retriever<TagWrapperType, MetaDataType> createMemoryRetriever() {
         BitmapProcessor bitmapProcessor = new TagWrapperValidityCheckBitmapProcessor();
-        return new MemoryRetriever<T, V>(cacheManager, bitmapProcessor);
+        return new MemoryRetriever<TagWrapperType, MetaDataType>(cacheManager, bitmapProcessor);
     }
 
-    public Retriever<T, V> createNetworkRetriever() {
+    public Retriever<TagWrapperType, MetaDataType> createNetworkRetriever() {
         Retriever fileRetriever = createFileRetriever();
         BitmapDecoder croppedDecoder = new DownsamplingBitmapDecoder(resources, DEFAULT_ALLOWED_STRETCHING_THRESHOLD, maxDownsampling);
-        Retriever networkRetriever = new NetworkRetriever<T, V>(resourceManager, fileManager, croppedDecoder, new DummyBitmapProcessor());
-        return new FallbackStrategyRetriever<T, V>(fileRetriever, networkRetriever);
+        Retriever networkRetriever = new NetworkRetriever<TagWrapperType, MetaDataType>(resourceManager, fileManager, croppedDecoder, new DummyBitmapProcessor());
+        return new FallbackStrategyRetriever<TagWrapperType, MetaDataType>(fileRetriever, networkRetriever);
     }
 
     public Retriever createFileRetriever() {
         BitmapDecoder croppedDecoder = new DownsamplingBitmapDecoder(resources, DEFAULT_ALLOWED_STRETCHING_THRESHOLD, maxDownsampling);
-        return new FileRetriever<T, V>(fileManager, croppedDecoder, new DummyBitmapProcessor());
+        return new FileRetriever<TagWrapperType, MetaDataType>(fileManager, croppedDecoder, new DummyBitmapProcessor());
     }
 
 }

--- a/core/src/main/java/com/novoda/pxfetcher/task/Retriever.java
+++ b/core/src/main/java/com/novoda/pxfetcher/task/Retriever.java
@@ -1,5 +1,5 @@
 package com.novoda.pxfetcher.task;
 
-public interface Retriever<T extends TagWrapper<V>,V> {
-    Result retrieve(T tagWrapper);
+public interface Retriever<TagWrapperType extends TagWrapper<MetadataType>, MetadataType> {
+    Result retrieve(TagWrapperType tagWrapper);
 }

--- a/core/src/main/java/com/novoda/pxfetcher/task/TagWrapper.java
+++ b/core/src/main/java/com/novoda/pxfetcher/task/TagWrapper.java
@@ -2,7 +2,7 @@ package com.novoda.pxfetcher.task;
 
 import com.novoda.pxfetcher.Tag;
 
-public abstract class TagWrapper<T> {
+public abstract class TagWrapper<MetadataType> {
 
     public static final int UNSPECIFIED = 0;
     private final Tag tag;
@@ -31,6 +31,6 @@ public abstract class TagWrapper<T> {
         return UNSPECIFIED;
     }
 
-    public abstract T getMetadata();
+    public abstract MetadataType getMetadata();
 
 }


### PR DESCRIPTION
Rename generic type variable T and V with TagWrapperType and Metadata to clarify the purpose of the generic types.