### PR TITLE
Simplify/Default fetcher

### DIFF
--- a/core/src/main/java/com/novoda/pxfetcher/DefaultImageViewCallback.java
+++ b/core/src/main/java/com/novoda/pxfetcher/DefaultImageViewCallback.java
@@ -44,11 +44,7 @@ public class DefaultImageViewCallback implements BitmapLoader.Callback {
         }
 
         Bitmap bitmap = ok.getBitmap();
-        if (ok instanceof MemoryRetriever.Success) {
-            imageView.setImageBitmap(bitmap);
-        } else {
-            imageSetter.setBitmap(imageView, bitmap);
-        }
+        imageSetter.setBitmap(imageView, bitmap);
         Tag.toSuccess(imageView);
     }
 

--- a/core/src/main/java/com/novoda/pxfetcher/PixelFetchers.java
+++ b/core/src/main/java/com/novoda/pxfetcher/PixelFetchers.java
@@ -74,7 +74,6 @@ public class PixelFetchers {
             if (Tag.shouldSkip(url, view)) {
                 return;
             }
-            view.setImageResource(PLACEHOLDER_RES_ID);
 
             TagWrapper<Void> tagWrapper = new DefaultTagWrapper(url);
             view.setTag(tagWrapper.getTag());


### PR DESCRIPTION
To simplify the default implementation of PixelFetcher 
- a duplicate placeholder setting was removed
- an unnecessary if clause was removed