### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-#Novoda image-loader is now deprecated and unmaintained. 
+# Novoda image-loader is now deprecated and unmaintained. 
 
 We will soon post here our recommendation for image loading in Android.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
